### PR TITLE
XLog 필터 후 드래그 선택시 404 에러 발생 수정 #153

### DIFF
--- a/src/components/Paper/XLog/Profiler/Profiler.js
+++ b/src/components/Paper/XLog/Profiler/Profiler.js
@@ -293,6 +293,10 @@ class Profiler extends Component {
         filtered = filtered.filter((d) => {
             return filterMap[d.objHash];
         });
+        //- 필터링 되어 비어있는 영역의 xlog 부터 카운팅이 0 인경우 조회 하지 않고 리턴
+        if( filtered.length === 0 ){
+            return;
+        }
 
         let date = moment(new Date(x1)).format("YYYYMMDD");
 


### PR DESCRIPTION
필터링 되어 비어있는 영역의 xlog 를 조회 시도를 해서 발생 하는 문제입니다. 
해당 문제 수정 했어요 

