### PR TITLE
innerLoading 콤포넌트 와 css namespace 충돌 현상 수정 #165

### DIFF
--- a/src/components/InnerLoading/InnerLoading.css
+++ b/src/components/InnerLoading/InnerLoading.css
@@ -1,4 +1,4 @@
-.loading {
+.innerLoading {
     z-index: 100;
     position: absolute;
     top : 0;
@@ -14,7 +14,7 @@
     text-align: center;
 }
 
-.loading > div {
+.innerLoading > div {
     z-index: 100;
     display: table-cell;
     vertical-align: middle;

--- a/src/components/InnerLoading/InnerLoading.js
+++ b/src/components/InnerLoading/InnerLoading.js
@@ -6,23 +6,22 @@ class InnerLoading extends Component {
     shouldComponentUpdate(nextProps, nextState) {
         return this.props.visible !== nextProps.visible;
     }
-
     componentDidUpdate(prevProps, prevState) {
 
         if (this.props.visible) {
-            this.refs.loading.style.display = "table";
-            this.refs.loading.style.opacity = "1";
+            this.refs.innerLoading.style.display = "table";
+            this.refs.innerLoading.style.opacity = "1";
         } else {
-            this.refs.loading.style.opacity = "0";
+            this.refs.innerLoading.style.opacity = "0";
             setTimeout(() => {
-                this.refs.loading.style.display = "none";
+                this.refs.innerLoading.style.display = "none";
             }, 500);
         }
     }
 
     render() {
         return (
-            <div className="loading" ref="loading">
+            <div className="innerLoading" ref="innerLoading">
                 <div>
                     <div className="spinner">
                         <div className="cube1"></div>


### PR DESCRIPTION
확인 결과 Loading 컴포넌트 와 InnerLoading 컴포넌트 간의 CSS 네임 스페이스 중복으로 되어
상위 Loading 컴포넌트의 .loading class가 무시되어 이런 현상이 발생 했네요 

InnerLoading 컴포넌트 CSS  네임 스페이스 변경 하여 해당 문제 수정 했습니다. 



