### PR TITLE
#145 에러메시지 창 개선

### DIFF
--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -147,10 +147,13 @@ class Paper extends Component {
                 beforeSend: function (xhr) {
                     setAuthHeader(xhr, that.props.config, that.props.user);
                 }
+
             }).done((msg) => {
                 this.tick(msg);
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+
+
+                errorHandler(xhr, textStatus, errorThrown, this.props, "getXLog", true);
             });
         }
     };
@@ -170,6 +173,7 @@ class Paper extends Component {
                 beforeSend: function (xhr) {
                     setAuthHeader(xhr, that.props.config, that.props.user);
                 }
+
             }).done((msg) => {
                 this.setState({
                     visitor: {
@@ -177,8 +181,10 @@ class Paper extends Component {
                         visitor: msg.result
                     }
                 });
+
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+                errorHandler(xhr, textStatus, errorThrown, this.props, "getVisitor", true);
+
             });
         }
     };
@@ -242,6 +248,7 @@ class Paper extends Component {
                         beforeSend: function (xhr) {
                             setAuthHeader(xhr, that.props.config, that.props.user);
                         }
+
                     }).done((msg) => {
                         this.counterHistoriesLoaded[counterKey] = true;
 
@@ -265,7 +272,7 @@ class Paper extends Component {
 
                     }).fail((xhr, textStatus, errorThrown) => {
                         this.counterHistoriesLoaded[counterKey] = true;
-                        errorHandler(xhr, textStatus, errorThrown, this.props);
+                        errorHandler(xhr, textStatus, errorThrown, this.props, "getCounter", true);
                     });
                 }
             }
@@ -307,8 +314,10 @@ class Paper extends Component {
                             data: map
                         }
                     });
+
+
                 }).fail((xhr, textStatus, errorThrown) => {
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "counterReady", true);
                 });
             }
         }


### PR DESCRIPTION
1. 기존 errorHandler 를 재정의하여 사용.
2. Local Storage 에 JSON 형태로 20개까지만 저장
   - JSON 형태 
      - {name:name, code:resultCode, msg:resultMsg} 
   - Key 내용
      - name : api 구분명, code: 리턴코드, msg : 리턴메세지
 
3.  기타 
    - Paper.js 에 있는 "/scouter/v1/xlog/realTime/" 의  리턴 dataType (text) 으로 인한 JSON 파싱 에러 예외 처리함.