### PR TITLE
#140 정렬하는 기능 & #145 에러메시지 창 개선 & #146 데이터 초기 로딩기능 & #182 XLog 필터 항목 추가

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -96,7 +96,7 @@ class App extends Component {
                 this.props.pushMessage("error", "CHECK SETTINGS", "current setting does not require authentication, but it actually requires authentication.");
                 this.props.setControlVisibility("Message", true);
             } else {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+                errorHandler(xhr, textStatus, errorThrown, this.props, "info", true);
             }
             localStorage.removeItem("user");
         }).always(() => {
@@ -247,7 +247,7 @@ class App extends Component {
                 }).fail((xhr, textStatus, errorThrown) => {
                     clearInterval(this.alertTimer);
                     this.alertTimer = null;
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "getRealTimeAlert", true);
                 });
             });
         }
@@ -274,7 +274,7 @@ class App extends Component {
                     this.props.pushMessage("error", "Not Supported", "failed to get matrix information. paper 2.0 is available only on scouter 2.0 and later.");
                     this.props.setControlVisibility("Message", true);
                 } else {
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "getCounterModel", true);
                 }
             }
         });

--- a/src/common/common.js
+++ b/src/common/common.js
@@ -444,6 +444,7 @@ export async function getFilteredData0(xlogs, filter, props) {
     let data = [];
     let temp = [];
 
+    // 서버에서 가져온 데이터를 필터로 정제...
     xlogs.forEach(async xlog => {
         if(dicts.size > Dictionary.bulkSize) {
             await Dictionary.record(dicts, props, moment(new Date(Number(data[data.length].endTime))).format("YYYYMMDD"));
@@ -482,6 +483,7 @@ export async function getFilteredData0(xlogs, filter, props) {
     return data;
 }
 
+// 서버에서 가져온 데이터와 필터 값과의 비교하는 함수
 export function getFilteredData (xlogs, filter) {
     let datas = xlogs;
 
@@ -545,6 +547,62 @@ export function getFilteredData (xlogs, filter) {
                     : d.userAgent === String(hash(filter.userAgent));
             });
         }
+
+        // filter - text
+        if (filter.text1) {
+            datas = datas.filter((d) => d.text1 === filter.text1);
+        }
+
+        if (filter.text2) {
+            datas = datas.filter((d) => d.text2 === filter.text2);
+        }
+
+        if (filter.text3) {
+            datas = datas.filter((d) => d.text3 === filter.text3);
+        }
+
+        if (filter.text4) {
+            datas = datas.filter((d) => d.text4 === filter.text4);
+        }
+
+        if (filter.text5) {
+            datas = datas.filter((d) => d.text5 === filter.text5);
+        }
+
+        // filter - profile count
+        if (filter.profileCountFrom) {
+            datas = datas.filter((d) => Number(d.profileCount) >= filter.profileCountFrom);
+        }
+
+        // filter - profile count
+        if (filter.profileCountFrom && filter.profileCountTo) {
+            datas = datas.filter((d) => (Number(d.profileCount) >= filter.profileCountFrom && Number(d.profileCount) <= filter.profileCountTo));
+        }
+
+        // filter - start Hms
+        if (filter.startHmsFrom && filter.startHmsTo) {
+            let dm = dateMillis(filter.startHmsFrom, filter.startHmsTo);
+            if(dm !== null) {
+                   datas = datas.filter((d) => (((Number(d.endTime) - Number(d.elapsed)) >= dm[0]) && ((Number(d.endTime) - Number(d.elapsed)) <= dm[1])));
+            }
+        }
+
+        switch (filter.hasDump) {
+
+            case "Y" : {
+                datas = datas.filter((d) => d.hasDump === "1");
+                break;
+            }
+
+            case "N" : {
+                datas = datas.filter((d) => d.hasDump === "0");
+                break;
+            }
+
+            default : {
+                break;
+            }
+        }
         
         switch (filter.type) {
             case "ERROR" : {
@@ -565,10 +623,30 @@ export function getFilteredData (xlogs, filter) {
             default : {
                 break;
             }
-        }            
+        }
+
     }
 
     return datas;
+}
+
+// from date string to millisecond
+export function dateMillis(startHmsFrom, startHmsTo) {
+
+    let dateObj = new Date();
+    let month = dateObj.getMonth();
+    let day = dateObj.getDate();
+    let year = dateObj.getFullYear();
+
+    let startFromTokens = startHmsFrom.split(":");
+    let startToTokens = startHmsTo.split(":");
+
+    let startFrom = (new Date(year, month, day, Number(startFromTokens[0]), Number(startFromTokens[1]), Number(startFromTokens[0]))).getTime();
+    let startTo = (new Date(year, month, day, Number(startToTokens[0]), Number(startToTokens[1]), Number(startToTokens[0]))).getTime();
+
+    if(isNaN(startFrom) || isNaN(startTo))
+        return null;
+    return startFrom + ":" + startTo;
 }
 
 export function updateQueryStringParameter(uri, key, value) {

--- a/src/components/Controller/Controller.js
+++ b/src/components/Controller/Controller.js
@@ -212,7 +212,7 @@ class Controller extends Component {
                 }
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "onServerClick", true);
         });
     };
 
@@ -296,7 +296,7 @@ class Controller extends Component {
                                 })
                             }
                         }).fail(function (xhr, textStatus, errorThrown) {
-                            errorHandler(xhr, textStatus, errorThrown, that.props);
+                            errorHandler(xhr, textStatus, errorThrown, that.props, "applyPreset_1", true);
                         });
                     });
 
@@ -332,7 +332,7 @@ class Controller extends Component {
             }
 
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "applyPreset_2", true);
         });
 
 
@@ -426,7 +426,7 @@ class Controller extends Component {
                                     })
                                 }
                             }).fail(function (xhr, textStatus, errorThrown) {
-                                errorHandler(xhr, textStatus, errorThrown, that.props);
+                                errorHandler(xhr, textStatus, errorThrown, that.props, "setTargetFromUrl_1", true);
                             });
                         });
 
@@ -462,7 +462,7 @@ class Controller extends Component {
                 }
 
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, that.props);
+                errorHandler(xhr, textStatus, errorThrown, that.props, "setTargetFromUrl_2", true);
             });
         }
     };
@@ -507,7 +507,7 @@ class Controller extends Component {
                 selectedObjects: {},
                 filter: ""
             });
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "getServers", true);
         }).always(() => {
             this.setState({
                 loading : false

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -128,7 +128,7 @@ class Login extends Component {
             }
 
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "login", true);
         }).always(() => {
             this.props.setControlVisibility("Loading", false);
         });

--- a/src/components/Menu/InstanceSelector/InstanceSelector.js
+++ b/src/components/Menu/InstanceSelector/InstanceSelector.js
@@ -75,11 +75,11 @@ class InstanceSelector extends Component {
                         });
                     }
                 }).fail((xhr, textStatus, errorThrown) => {
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "savePreset_1", true);
                 });
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "savePreset_2", true);
         });
     };
 

--- a/src/components/Menu/LayoutManager/LayoutManager.js
+++ b/src/components/Menu/LayoutManager/LayoutManager.js
@@ -61,7 +61,7 @@ class LayoutManager extends Component {
                 });
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "saveTemplate", true);
         });
     };
 
@@ -132,7 +132,7 @@ class LayoutManager extends Component {
                 }
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "loadTemplates", true);
         });
     };
 

--- a/src/components/Menu/PresetManager/PresetManager.js
+++ b/src/components/Menu/PresetManager/PresetManager.js
@@ -61,7 +61,7 @@ class PresetManager extends Component {
                 });
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "savePreset", true);
         }).always(() => {
             this.setState({
                 loading : false
@@ -96,7 +96,7 @@ class PresetManager extends Component {
                 }
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "loadPresets", true);
         }).always(() => {
             this.setState({
                 loading : false

--- a/src/components/ObjectSelector/ObjectSelector.js
+++ b/src/components/ObjectSelector/ObjectSelector.js
@@ -219,7 +219,7 @@ class ObjectSelector extends Component {
                                     })
                                 }
                             }).fail(function (xhr, textStatus, errorThrown) {
-                                errorHandler(xhr, textStatus, errorThrown, that.props);
+                                errorHandler(xhr, textStatus, errorThrown, that.props, "setTargetFromUrl_1", true);
                             });
                         });
 
@@ -255,7 +255,7 @@ class ObjectSelector extends Component {
                 }
 
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, that.props);
+                errorHandler(xhr, textStatus, errorThrown, that.props, "setTargetFromUrl_2", true);
             });
         }
     };
@@ -300,7 +300,7 @@ class ObjectSelector extends Component {
                 selectedObjects: {},
                 filter: ""
             });
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "getServers", true);
         }).always(() => {
             this.setState({
                 loading : false
@@ -350,7 +350,7 @@ class ObjectSelector extends Component {
                 }
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "onServerClick", true);
         });
     };
 
@@ -460,11 +460,11 @@ class ObjectSelector extends Component {
                         });
                     }
                 }).fail((xhr, textStatus, errorThrown) => {
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "savePreset_1", true);
                 });
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "savePreset_2", true);
         });
     };
 

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -568,7 +568,7 @@ class Paper extends Component {
                             return Number(obj.objHash);
                     })) +"&startYmd=" + moment(startTime).format("YYYYMMDD")
                         + "&endYmd=" + moment(endTime).format("YYYYMMDD");
-                    this.getCounterHistoryData(url, counterKey, from, to, now, false, false);
+                    this.getCounterHistoryData(url, counterKey, from, to, now, false);
 
                 } else {
                     url = getHttpProtocol(this.props.config) + '/scouter/v1/counter/' + encodeURI(counterKey) + '?objHashes=' + JSON.stringify(objects.filter((d) => {
@@ -577,7 +577,7 @@ class Paper extends Component {
                         return Number(obj.objHash);
                 })) +"&startTimeMillis=" + startTime + "&endTimeMillis="
                     + endTime;
-                    this.getCounterHistoryData(url, counterKey, from, to, now, false, false);
+                    this.getCounterHistoryData(url, counterKey, from, to, now, false);
                 }
             }
 
@@ -980,8 +980,8 @@ class Paper extends Component {
     };
 
 
-    getCounterHistoryData = (url, counterKey, from, to, now, append, gb) => {
-        //this.setLoading(true);
+    getCounterHistoryData = (url, counterKey, from, to, now, append) => {
+        this.setLoading(true);
         let that = this;
         this.props.addRequest();
         jQuery.ajax({
@@ -1087,7 +1087,7 @@ class Paper extends Component {
 
             this.counterHistoriesLoaded[counterKey] = true;
 
-            //this.setLoading(false);
+            this.setLoading(false);
         }).fail((xhr, textStatus, errorThrown) => {
             errorHandler(xhr, textStatus, errorThrown, this.props, "getCounterHistoryData", true);
         });

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -93,7 +93,7 @@ class Paper extends Component {
                     }
                 }
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+                errorHandler(xhr, textStatus, errorThrown, this.props, "layout", true);
             });
         }
 
@@ -475,7 +475,7 @@ class Paper extends Component {
                         }
                     });
                 }).fail((xhr, textStatus, errorThrown) => {
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "getRealTimeCounter", true);
                 });
             } else {
                 let now = (new ServerDate()).getTime();
@@ -722,7 +722,7 @@ class Paper extends Component {
                 });
 
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+                errorHandler(xhr, textStatus, errorThrown, this.props, "getXLog", true);
             });
         }
     };
@@ -895,7 +895,7 @@ class Paper extends Component {
                 }
 
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+                errorHandler(xhr, textStatus, errorThrown, this.props, "getXLogHistoryData", true);
             });
         }
     };
@@ -931,7 +931,7 @@ class Paper extends Component {
                         }
                     });
                 }).fail((xhr, textStatus, errorThrown) => {
-                    errorHandler(xhr, textStatus, errorThrown, props);
+                    errorHandler(xhr, textStatus, errorThrown, props, "getVisitor", true);
                 });
             } else {
                 let time = (new ServerDate()).getTime();
@@ -1048,7 +1048,7 @@ class Paper extends Component {
 
             this.setLoading(false);
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "getCounterHistoryData", true);
         });
     };
 

--- a/src/components/Paper/XLog/Profiler/ProfileList/ProfileList.js
+++ b/src/components/Paper/XLog/Profiler/ProfileList/ProfileList.js
@@ -168,7 +168,22 @@ class ProfileList extends Component {
         this.fullTimeFormat = this.props.config.dateFormat + " " + this.props.config.timeFormat;
     }
 
+    sortTemp = null;
+    // data sorting
+    onSort(event, sortKey) {
 
+        const data = this.props.xlogs;
+
+        if (this.sortTemp !== sortKey) {
+            data.sort((a, b) => a[sortKey].localeCompare(b[sortKey]));
+            this.sortTemp = sortKey;
+        }else{
+            data.sort((a, b) => b[sortKey].localeCompare(a[sortKey]));
+            this.sortTemp = null;
+        }
+
+        this.setState({data});
+    }
 
     getRow = (row, i) => {
         return layout.map((meta, j) => {
@@ -192,7 +207,7 @@ class ProfileList extends Component {
 
     getHeader = () => {
         return layout.map((meta, j) => {
-            return <span key={j}>{meta.name}</span>
+            return <span key={j} onClick={e => this.onSort(e, meta.key)}>{meta.name}</span>
         });
     };
 

--- a/src/components/Paper/XLog/Profiler/ProfileList/ProfileList.js
+++ b/src/components/Paper/XLog/Profiler/ProfileList/ProfileList.js
@@ -170,16 +170,29 @@ class ProfileList extends Component {
 
     sortTemp = null;
     // data sorting
-    onSort(event, sortKey) {
+    onSort(event, type, sortKey) {
 
         const data = this.props.xlogs;
 
-        if (this.sortTemp !== sortKey) {
-            data.sort((a, b) => a[sortKey].localeCompare(b[sortKey]));
-            this.sortTemp = sortKey;
+        if (type === "number" || type === "ms" || type === "kbytes") {
+
+            if (this.sortTemp !== sortKey) {
+                data.sort((a, b) => a[sortKey].localeCompare(b[sortKey], 'en-US', { numeric: true, sensitivity: 'base' }));
+                this.sortTemp = sortKey;
+            }else{
+                data.sort((a, b) => b[sortKey].localeCompare(a[sortKey], 'en-US', { numeric: true, sensitivity: 'base' }));
+                this.sortTemp = null;
+            }
+
         }else{
-            data.sort((a, b) => b[sortKey].localeCompare(a[sortKey]));
-            this.sortTemp = null;
+
+            if (this.sortTemp !== sortKey) {
+                data.sort((a, b) => a[sortKey].localeCompare(b[sortKey]));
+                this.sortTemp = sortKey;
+            }else{
+                data.sort((a, b) => b[sortKey].localeCompare(a[sortKey]));
+                this.sortTemp = null;
+            }
         }
 
         this.setState({data});
@@ -207,7 +220,7 @@ class ProfileList extends Component {
 
     getHeader = () => {
         return layout.map((meta, j) => {
-            return <span key={j} onClick={e => this.onSort(e, meta.key)}>{meta.name}</span>
+            return <span key={j} onClick={e => this.onSort(e, meta.type, meta.key)}>{meta.name}</span>
         });
     };
 

--- a/src/components/Paper/XLog/Profiler/Profiler.js
+++ b/src/components/Paper/XLog/Profiler/Profiler.js
@@ -342,7 +342,7 @@ class Profiler extends Component {
             }
 
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "getListData", true);
         }).always(() => {
             this.props.setControlVisibility("Loading", false);
         });
@@ -450,14 +450,14 @@ class Profiler extends Component {
                     });
 
                 }).fail((xhr, textStatus, errorThrown) => {
-                    errorHandler(xhr, textStatus, errorThrown, this.props);
+                    errorHandler(xhr, textStatus, errorThrown, this.props, "rowClick_1", true);
                 }).always(() => {
                     this.props.setControlVisibility("Loading", false);
                 });
             }
 
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, this.props);
+            errorHandler(xhr, textStatus, errorThrown, this.props, "rowClick_2", true);
             this.props.setControlVisibility("Loading", false);
         }).always(() => {
             this.props.setControlVisibility("Loading", false);

--- a/src/components/Paper/XLogFilter/XLogFilter.js
+++ b/src/components/Paper/XLogFilter/XLogFilter.js
@@ -25,7 +25,17 @@ class XLogFilter extends Component {
             loginMatcher : null,
             descMatcher : null,
             addressMatcher : null,
-            small : false
+            small : false,
+            hasDump : "ALL",
+            startHmsFrom : "",
+            startHmsTo : "",
+            profileCountFrom : "",
+            profileCountTo : "",
+            text1 : "",
+            text2 : "",
+            text3 : "",
+            text4 : "",
+            text5 : ""
         };
     }
 
@@ -66,13 +76,29 @@ class XLogFilter extends Component {
             referrer : this.props.filterInfo.referrer ? this.props.filterInfo.referrer : "",
             login : this.props.filterInfo.login ? this.props.filterInfo.login : "",
             desc : this.props.filterInfo.desc ? this.props.filterInfo.desc : "",
-            userAgent : this.props.filterInfo.userAgent ? this.props.filterInfo.userAgent : ""
+            userAgent : this.props.filterInfo.userAgent ? this.props.filterInfo.userAgent : "",
+            hasDump : this.props.filterInfo.hasDump ? this.props.filterInfo.hasDump : "ALL",
+            startHmsFrom : this.props.filterInfo.startHmsFrom ? this.props.filterInfo.startHmsFrom : "",
+            startHmsTo : this.props.filterInfo.startHmsTo ? this.props.filterInfo.startHmsTo : "",
+            profileCountFrom : this.props.filterInfo.profileCountFrom ? this.props.filterInfo.profileCountFrom : "",
+            profileCountTo : this.props.filterInfo.profileCountTo ? this.props.filterInfo.profileCountTo : "",
+            text1 : this.props.filterInfo.text1 ? this.props.filterInfo.text1 : "",
+            text2 : this.props.filterInfo.text2 ? this.props.filterInfo.text2 : "",
+            text3 : this.props.filterInfo.text3 ? this.props.filterInfo.text3 : "",
+            text4 : this.props.filterInfo.text4 ? this.props.filterInfo.text4 : "",
+            text5 : this.props.filterInfo.text5 ? this.props.filterInfo.text5 : ""
         });
     }
 
     onChangeType = (type) => {
         this.setState({
             type : type
+        });
+    };
+
+    onChangeHasDump = (hasDump) => {
+        this.setState({
+            hasDump : hasDump
         });
     };
 
@@ -169,6 +195,55 @@ class XLogFilter extends Component {
                                 <div className="xlog-filter-content-row-label">REFERRER</div>
                                 <div className="xlog-filter-content-row-control"><input type="text" onChange={this.onChangeCondition.bind(this, "referrer")} value={this.state.referrer} /></div>
                             </div>
+                            <div className="xlog-filter-content-row">
+                                <div className="xlog-filter-content-row-label">HAS DUMP</div>
+                                <div className="xlog-filter-content-row-control type-control">
+                                    <button className={this.state.hasDump === "ALL" ? "active" : ""} onClick={this.onChangeHasDump.bind(this, "ALL")}>ALL</button>
+                                    <button className={this.state.hasDump === "Y" ? "active" : ""} onClick={this.onChangeHasDump.bind(this, "Y")}>Y</button>
+                                    <button className={this.state.hasDump === "N" ? "active" : ""} onClick={this.onChangeHasDump.bind(this, "N")}>N</button>
+                                </div>
+                            </div>
+                            <div className="xlog-filter-content-row xlog-filter-elapsed">
+                                <div className="xlog-filter-content-row-label">PROFILE COUNTER</div>
+                                <div className="xlog-filter-content-row-control">
+                                    <input type="number" onChange={this.onChangeCondition.bind(this, "profileCountFrom")} value={this.state.profileCountFrom}/>
+                                </div>
+                                <div className="xlog-filter-content-row-text">~</div>
+                                <div className="xlog-filter-content-row-control">
+                                    <input type="number" onChange={this.onChangeCondition.bind(this, "profileCountTo")} value={this.state.profileCountTo}/>
+                                </div>
+                            </div>
+                            <div className="xlog-filter-content-row xlog-filter-elapsed">
+                                <div className="xlog-filter-content-row-label">START TIME</div>
+                                <div className="xlog-filter-content-row-control">
+                                    <input type="text" onChange={this.onChangeCondition.bind(this, "startHmsFrom")} value={this.state.startHmsFrom} placeholder="HH:MM:SS"/>
+                                </div>
+                            <div className="xlog-filter-content-row-text">~</div>
+                                <div className="xlog-filter-content-row-control">
+                                    <input type="text" onChange={this.onChangeCondition.bind(this, "startHmsTo")} value={this.state.startHmsTo} placeholder="HH:MM:SS"/>
+                                </div>
+                            </div>
+                            <div className="xlog-filter-content-row half">
+                                <div className="xlog-filter-content-row-label">TEXT1</div>
+                                <div className="xlog-filter-content-row-control"><input type="text" onChange={this.onChangeCondition.bind(this, "text1")} value={this.state.text1} /></div>
+                            </div>
+                            <div className="xlog-filter-content-row half">
+                                <div className="xlog-filter-content-row-label">TEXT2</div>
+                                <div className="xlog-filter-content-row-control"><input type="text" onChange={this.onChangeCondition.bind(this, "text2")} value={this.state.text2} /></div>
+                            </div>
+                            <div className="xlog-filter-content-row half">
+                                <div className="xlog-filter-content-row-label">TEXT3</div>
+                                <div className="xlog-filter-content-row-control"><input type="text" onChange={this.onChangeCondition.bind(this, "text3")} value={this.state.text3} /></div>
+                            </div>
+                            <div className="xlog-filter-content-row half">
+                                <div className="xlog-filter-content-row-label">TEXT4</div>
+                                <div className="xlog-filter-content-row-control"><input type="text" onChange={this.onChangeCondition.bind(this, "text4")} value={this.state.text4} /></div>
+                            </div>
+                            <div className="xlog-filter-content-row half">
+                                <div className="xlog-filter-content-row-label">TEXT5</div>
+                                <div className="xlog-filter-content-row-control"><input type="text" onChange={this.onChangeCondition.bind(this, "text5")} value={this.state.text5} /></div>
+                            </div>
+
                         </div>
                         <div className="xlog-filter-btns">
                             <button onClick={this.onClear}>CLEAR FILTER</button>

--- a/src/components/Paper/XLogFilter/XLogFilter.js
+++ b/src/components/Paper/XLogFilter/XLogFilter.js
@@ -206,11 +206,11 @@ class XLogFilter extends Component {
                             <div className="xlog-filter-content-row xlog-filter-elapsed">
                                 <div className="xlog-filter-content-row-label">PROFILE COUNTER</div>
                                 <div className="xlog-filter-content-row-control">
-                                    <input type="number" onChange={this.onChangeCondition.bind(this, "profileCountFrom")} value={this.state.profileCountFrom}/>
+                                    <input type="number" onChange={this.onChangeCondition.bind(this, "profileCountFrom")} value={this.state.profileCountFrom} min="0"/>
                                 </div>
                                 <div className="xlog-filter-content-row-text">~</div>
                                 <div className="xlog-filter-content-row-control">
-                                    <input type="number" onChange={this.onChangeCondition.bind(this, "profileCountTo")} value={this.state.profileCountTo}/>
+                                    <input type="number" onChange={this.onChangeCondition.bind(this, "profileCountTo")} value={this.state.profileCountTo} min="1"/>
                                 </div>
                             </div>
                             <div className="xlog-filter-content-row xlog-filter-elapsed">

--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -565,6 +565,17 @@ class Settings extends Component {
                                     <input type="number" required min={60} step={60} readOnly={!this.state.edit} onChange={this.onChangeRange.bind(this, "longHistoryStep")} value={this.state.config.range.longHistoryStep} placeholder="MINUTES" />
                                 </div>
                             </div>
+                            <div className="row">
+                                <div className="label">
+                                    <div>DATA PRELOAD</div>
+                                </div>
+                                <div className="input">
+                                    <select value={this.state.config.preload} onChange={this.onChange.bind(this, "preload")} disabled={!this.state.edit}>
+                                        <option value="Y">Y</option>
+                                        <option value="N">N</option>
+                                    </select>
+                                </div>
+                            </div>
                         </div>
                         <div className="category first">
                             <div>ALERT</div>

--- a/src/components/Topology/Topology.js
+++ b/src/components/Topology/Topology.js
@@ -260,7 +260,7 @@ class Topology extends Component {
                 servers: [],
                 objects: []
             });
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "getAllInstanceInfo", true);
         }).always(() => {
             this.setState({
                 loading: false
@@ -295,7 +295,7 @@ class Topology extends Component {
                 }
             }
         }).fail((xhr, textStatus, errorThrown) => {
-            errorHandler(xhr, textStatus, errorThrown, that.props);
+            errorHandler(xhr, textStatus, errorThrown, that.props, "getInstanceList", true);
         });
     };
 
@@ -590,7 +590,7 @@ class Topology extends Component {
                 }
 
             }).fail((xhr, textStatus, errorThrown) => {
-                errorHandler(xhr, textStatus, errorThrown, this.props);
+                errorHandler(xhr, textStatus, errorThrown, this.props, "getTopology", true);
             });
         } else {
             this.nodes= [];

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -12,6 +12,7 @@ const configState = {
         }
     ],
     interval: 2000,
+    preload: "N",
     alertInterval : 60,
     numberFormat: "0,0.0",
     decimalPoint: 1,
@@ -514,12 +515,12 @@ let topologyOptionState = {
     tpsToLineSpeed : true,
     speedLevel : "fast",
     redLine : false,
-    highlight : false,
+    highlight : true,
     distance : 300,
     zoom : false,
-    pin : false,
+    pin : true,
     lastUpdateTime : null,
-    grouping : false,
+    grouping : true,
     nodeCount : 0,
     linkCount : 0
 };


### PR DESCRIPTION
### [#140] XLog 목록 테이블에 헤더로 정렬하는 기능 추가
### [#145] 에러메시지 창 개선

- 기존 errorHandler 재정의
- Local Storage 에 JSON 형태로 최신 20개만 저장 & console.error 추가
  - JSON 형태
    - {name:name, code:resultCode, msg:resultMsg}
  - Key 내용
    - name : API 구분명, code: 리턴코드, msg : 리턴메세지


### [#146] 페이퍼 메뉴로 들어가는 경우 라인차트의 데이터를 초기 로딩하지 않는 옵션을 추가한다. 
- SETTING> POOLING & RANGE > DATA PRELOAD 를 Y/N 로 설정 (defalut value 는 N)
![image](https://user-images.githubusercontent.com/13757297/55451527-45144d00-560e-11e9-9473-b771876e856e.png)
- 라인 차트 데이터 리로드 기능 추가
![image](https://user-images.githubusercontent.com/13757297/55451531-480f3d80-560e-11e9-854e-5f483a0c4eee.png)

### [#182] XLog 필터 항목 추가 
- XLog 필터 항목 추가
  - HAS DUMP (ALL/Y/N)
  - PROFILE COUNTER (X ~ Y)
  - START TIME (HH:MM:SS ~ HH:MM:SS)
  - TEXT1 ~ TEXT5
![image](https://user-images.githubusercontent.com/13757297/55451661-d8e61900-560e-11e9-8e6a-1ec04e2a1266.png)