### PR TITLE
차트 타입에 Stack Type 추가  #148

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -367,12 +367,13 @@ export function setActiveServiceList(object){
         object : object
     }
 }
-export function setTimeFocus(active,time,boxKey){
+export function setTimeFocus(active,time,boxKey,keep=false){
     return {
         type : SET_TIME_FOCUS,
         id: boxKey,
         active :active,
         time : time,
+        keep : keep
     }
 
 }

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -43,6 +43,9 @@ export const SET_TEMPLATE_NAME = 'SET_TEMPLATE_NAME';
 export const SET_PRESET_NAME = 'SET_PRESET_NAME';
 export const SET_LAYOUT_NAME = 'SET_LAYOUT_NAME';
 
+
+export const SET_TIME_FOCUS = 'SET_TIME_FOCUS';
+
 export function setTemplateName(preset, layout) {
     return {
         type: SET_TEMPLATE_NAME,
@@ -363,4 +366,13 @@ export function setActiveServiceList(object){
         type : SET_ACTIVE_SERVICE,
         object : object
     }
+}
+export function setTimeFocus(active,time,boxKey){
+    return {
+        type : SET_TIME_FOCUS,
+        id: boxKey,
+        active :active,
+        time : time,
+    }
+
 }

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -120,6 +120,8 @@ class Box extends Component {
                     titles : {}
                 });
             }
+            console.log('========================> add metric config..', this.props.box);
+
             this.props.setOption(this.props.box.key, option);
         }
     }

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -120,8 +120,6 @@ class Box extends Component {
                     titles : {}
                 });
             }
-            console.log('========================> add metric config..', this.props.box);
-
             this.props.setOption(this.props.box.key, option);
         }
     }

--- a/src/components/Box/Tooltip/Tooltip.js
+++ b/src/components/Box/Tooltip/Tooltip.js
@@ -72,7 +72,7 @@ class Tooltip extends Component {
             <div ref="tooltipRoot" className={"tooltip " + (hasData ? '' : 'no-data')} style={{left: x, top: y}}>
                 {show && this.props.tooltip.data &&
                 <div>
-                    <div className="time">{this.props.tooltip.data.time}</div>
+                    <div className="time">{this.props.tooltip.data.time} {`${this.props.tooltip.data.chartType === "STACK AREA" ? "Sum :"+this.props.tooltip.data.counterSum : "" }`}</div>
                     <ul>
                         {this.props.tooltip.data.lines.map((d, i) => {
                             return (

--- a/src/components/Controller/Controller.js
+++ b/src/components/Controller/Controller.js
@@ -735,7 +735,6 @@ class Controller extends Component {
     setOption = (key, option) => {
 
         let boxes = this.props.boxes.slice(0);
-
         boxes.forEach((box) => {
             if (box.key === key) {
 
@@ -775,6 +774,9 @@ class Controller extends Component {
                             familyName: option.familyName
                         });
                     }
+                    if(!box.advancedOption && option.advancedOption ){
+                        box.advancedOption = option.advancedOption;
+                    }
                 }
 
                 box.values = {};
@@ -808,7 +810,6 @@ class Controller extends Component {
 
     addPaperAndAddMetric = (data) => {
         let key = this.addPaper();
-
         if (data) {
             let option = JSON.parse(data);
             this.setOption(key, option);

--- a/src/components/Paper/BoxConfig/BoxConfig.css
+++ b/src/components/Paper/BoxConfig/BoxConfig.css
@@ -61,6 +61,7 @@
     box-sizing: border-box;
 }
 
+
 .box-config.single-row .box-config-items {
     display: block;
 }
@@ -97,7 +98,41 @@
     border-radius: 0;
 
 }
+/* 메트릭 추가 설정 */
+.box-config .box-config-advanced-items {
+    display: table;
+    width: 100%;
+    table-layout: fixed;
+}
 
+.box-config .box-config-advanced-item {
+    padding: 2px 0 5px;
+    width: 50%;
+    _height: 46px;
+    display: inline-block;
+    position: relative;
+    vertical-align: top;
+    box-sizing: border-box;
+}
+
+.box-config .box-config-advanced-item select {
+    width: calc(100% - 120px);
+    padding: 5px;
+    outline: none;
+    border-radius: 3px;
+    border: none;
+    line-height: 0;
+}
+
+.box-config .box-config-advanced-item label {
+    color: white;
+
+    line-height: 100%;
+    width: 100px;
+    display: inline-block;
+    text-align: center;
+}
+/* 추가 설정 분 */
 .box-config .box-config-buttons {
     padding: 5px 10px 0;
     text-align: center;

--- a/src/components/Paper/BoxConfig/BoxConfig.js
+++ b/src/components/Paper/BoxConfig/BoxConfig.js
@@ -117,7 +117,7 @@ class BoxConfig extends Component {
                     }
                     </div>
                     <div className="box-config-items">
-                    {this.props.box.option && this.props.box.option.config && Object.keys(this.props.box.option.config).map((attr, i) => {
+                    { this.props.box.option && this.props.box.option.config && Object.keys(this.props.box.option.config).map((attr, i) => {
                         if (this.props.box.option.config[attr].type === "input") {
                             return <div className="box-config-item" key={i}>
                                         <label>{this.props.box.option.config[attr].name}</label>
@@ -158,8 +158,27 @@ class BoxConfig extends Component {
                         } else {
                             return undefined;
                         }
-                    })}
+                    })
+                    }
                     </div>
+                    <div className="box-config-advanced-items">
+                    { this.props.box.advancedOption && Object.keys(this.props.box.advancedOption).map((attr, i) => {
+                            if (this.props.box.advancedOption[attr].type === "selector") {
+                                return <div className="box-config-advanced-item" key={i}>
+                                    <label>{this.props.box.advancedOption[attr].name}</label>
+                                    <select onChange={this.onChange.bind(this, attr)} defaultValue={this.state.values[attr]}>
+                                        {this.props.box.advancedOption[attr].data.map((d, i) => {
+                                            return <option key={i}>{d}</option>
+                                        })}
+                                    </select>
+                                </div>
+                            }else{
+                                return undefined;
+                            }
+                        })
+                    }
+                    </div>
+
                     <div className="box-config-buttons">
                         <button onClick={this.onCancel}>CANCEL</button><button onClick={this.onApply}>APPLY</button>
                     </div>

--- a/src/components/Paper/BoxConfig/BoxConfig.js
+++ b/src/components/Paper/BoxConfig/BoxConfig.js
@@ -1,5 +1,7 @@
 import React, {Component} from 'react';
 import './BoxConfig.css';
+import connect from "react-redux/es/connect/connect";
+import {pushMessage, setControlVisibility} from "../../../actions";
 
 class BoxConfig extends Component {
 
@@ -57,6 +59,25 @@ class BoxConfig extends Component {
     };
 
     onApply = () => {
+        //- stack area apply option couter check...
+
+        if( this.props.box.advancedOption && Object.keys(this.state.values).filter(attr =>
+                this.state.values[attr].indexOf("STACK")> -1 ? true : false
+            ).length > 0
+        ){
+            let removeKeyTotal = 0;
+            if( this.state.removeKeys ){
+                removeKeyTotal = this.state.removeKeys.length;
+            }
+            const counterKeyTotal = this.props.box.option.length - removeKeyTotal;
+            if( counterKeyTotal > 1 ){
+                this.props.pushMessage("error","Stack Area Info","Only one metric is available");
+                this.props.setControlVisibility("Message", true);
+                return;
+            }
+
+        }
+
 
         if (this.state.removeKeys && this.state.removeKeys.length > 0) {
             this.props.removeMetrics(this.props.box.key, this.state.removeKeys)
@@ -90,13 +111,29 @@ class BoxConfig extends Component {
     };
 
     render() {
-        console.log("box config open",this.props.box);
         return (
             <div className={"box-config popup-div " + (this.state.singleRow ? "single-row" : "")} onMouseDown={(e) => {e.stopPropagation();}} onMouseUp={(e) => {e.stopPropagation();}} ref="boxConfig">
                 <div className="box-config-content">
                     <div className="box-config-title">
                         <span>CONFIG</span>
                         <span className="close-btn" onClick={this.onCancel}><i className="fa fa-times-circle-o" aria-hidden="true"></i></span>
+                    </div>
+                    <div className="box-config-advanced-items">
+                        { this.props.box.advancedOption && Object.keys(this.props.box.advancedOption).map((attr, i) => {
+                            if (this.props.box.advancedOption[attr].type === "selector") {
+                                return <div className="box-config-advanced-item" key={i}>
+                                    <label>{this.props.box.advancedOption[attr].name}</label>
+                                    <select onChange={(e)=>this.onChange(attr,e)} defaultValue={this.state.values[attr]}>
+                                        {this.props.box.advancedOption[attr].data.map((d, i) => {
+                                            return <option key={i}>{d}</option>
+                                        })}
+                                    </select>
+                                </div>
+                            }else{
+                                return undefined;
+                            }
+                        })
+                        }
                     </div>
                     <div className={"exclusive-options " + (this.props.box.option.length > 0 ? 'show' : '')}>
                     {(this.props.box.option && this.props.box.option.length > 0) &&
@@ -161,23 +198,7 @@ class BoxConfig extends Component {
                     })
                     }
                     </div>
-                    <div className="box-config-advanced-items">
-                    { this.props.box.advancedOption && Object.keys(this.props.box.advancedOption).map((attr, i) => {
-                            if (this.props.box.advancedOption[attr].type === "selector") {
-                                return <div className="box-config-advanced-item" key={i}>
-                                    <label>{this.props.box.advancedOption[attr].name}</label>
-                                    <select onChange={this.onChange.bind(this, attr)} defaultValue={this.state.values[attr]}>
-                                        {this.props.box.advancedOption[attr].data.map((d, i) => {
-                                            return <option key={i}>{d}</option>
-                                        })}
-                                    </select>
-                                </div>
-                            }else{
-                                return undefined;
-                            }
-                        })
-                    }
-                    </div>
+
 
                     <div className="box-config-buttons">
                         <button onClick={this.onCancel}>CANCEL</button><button onClick={this.onApply}>APPLY</button>
@@ -187,7 +208,12 @@ class BoxConfig extends Component {
         );
     }
 }
-
-
+let mapDispatchToProps = (dispatch) => {
+    return {
+        pushMessage: (category, title, content) => dispatch(pushMessage(category, title, content)),
+        setControlVisibility: (name, value) => dispatch(setControlVisibility(name, value)),
+    };
+};
+BoxConfig = connect(null, mapDispatchToProps)(BoxConfig)
 export default BoxConfig;
 

--- a/src/components/Paper/BoxConfig/BoxConfig.js
+++ b/src/components/Paper/BoxConfig/BoxConfig.js
@@ -90,6 +90,7 @@ class BoxConfig extends Component {
     };
 
     render() {
+        console.log("box config open",this.props.box);
         return (
             <div className={"box-config popup-div " + (this.state.singleRow ? "single-row" : "")} onMouseDown={(e) => {e.stopPropagation();}} onMouseUp={(e) => {e.stopPropagation();}} ref="boxConfig">
                 <div className="box-config-content">

--- a/src/components/Paper/BoxConfig/BoxConfig.js
+++ b/src/components/Paper/BoxConfig/BoxConfig.js
@@ -81,6 +81,9 @@ class BoxConfig extends Component {
 
         if (this.state.removeKeys && this.state.removeKeys.length > 0) {
             this.props.removeMetrics(this.props.box.key, this.state.removeKeys)
+            if( Object.keys(this.state.values).filter(attr => this.state.values[attr] === "STACK AREA" ? true : false).length > 0){
+                this.props.setOptionValues(this.props.box.key, this.state.values);
+            }
         } else {
             this.props.setOptionValues(this.props.box.key, this.state.values);
         }

--- a/src/components/Paper/LineChart/LineChart.css
+++ b/src/components/Paper/LineChart/LineChart.css
@@ -45,7 +45,12 @@
     stroke-dasharray: 3, 3;
     opacity: 0.5;
 }
-
+.focus-hover-line {
+    stroke: #e08429;
+    stroke-width: 2px;
+    stroke-dasharray: 3, 3;
+    opacity: 1;
+}
 .tooltip-focus circle {
     fill: none;
     stroke-width: 2px;

--- a/src/components/Paper/LineChart/LineChart.css
+++ b/src/components/Paper/LineChart/LineChart.css
@@ -48,7 +48,7 @@
 .focus-hover-line {
     stroke: #e08429;
     stroke-width: 2px;
-    stroke-dasharray: 3, 3;
+    stroke-dasharray: 2, 2;
     opacity: 1;
 }
 .tooltip-focus circle {

--- a/src/components/Paper/LineChart/LineChart.css
+++ b/src/components/Paper/LineChart/LineChart.css
@@ -46,10 +46,10 @@
     opacity: 0.5;
 }
 .focus-hover-line {
-    stroke: #e08429;
-    stroke-width: 2px;
-    stroke-dasharray: 2, 2;
-    opacity: 1;
+    stroke: #6F257F;
+    stroke-width: 3px;
+    /*stroke-dasharray: 2, 2;*/
+    opacity: 0.5;
 }
 .tooltip-focus circle {
     fill: none;

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -203,9 +203,6 @@ class LineChart extends Component {
         //-
         this.chartType = nextProps.box.values['chartType'];
         this.showTimeFocus(nextProps.timeFocus.active);
-
-
-
     }
 
     loadHistoryCounter(countersHistory, counterKey, longTerm) {
@@ -829,6 +826,8 @@ class LineChart extends Component {
         if ((box.offsetWidth - this.graph.margin.left - this.graph.margin.right !== this.graph.width) || (this.graph.height !== box.offsetHeight - this.graph.margin.top - this.graph.margin.bottom - 27)) {
             resized = true;
             this.graphInit();
+            this.manualTooltipHide();
+            this.props.setTimeFocus(false,null,this.props.box.key);
         }
 
         return resized;

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -13,7 +13,7 @@ class LineChart extends Component {
     lastCountersTime = null;
     lastCountersHistoryTime = null;
     historyInit = {};
-
+    chartType = "LINE";
     graph = {
         margin: {
             top: 15, right: 15, bottom: 25, left: 40
@@ -72,6 +72,14 @@ class LineChart extends Component {
 
     componentWillReceiveProps(nextProps) {
         let counters = Object.assign({}, this.state.counters);
+
+        //- LINE FILL => LINE Change 할경우
+        if( nextProps.box.values['chartType'] !== this.chartType){
+            if( nextProps.box.values['chartType'] === 'LINE' && this.chartType === 'LINE FILL' ){
+                this.removeLineFill();
+            }
+        }
+
         if (nextProps.countersHistory && this.lastCountersHistoryTime !== nextProps.countersHistoryTimestamp) {
 
             this.lastCountersHistoryTime = nextProps.countersHistoryTimestamp;
@@ -169,6 +177,7 @@ class LineChart extends Component {
             });
 
         }
+        this.chartType = nextProps.box.values['chartType'];
 
     }
 
@@ -301,7 +310,6 @@ class LineChart extends Component {
     }
 
     componentDidUpdate = (prevProps, prevState) => {
-
         if (prevProps.layoutChangeTime !== this.props.layoutChangeTime) {
             if (this.graphResize()) {
                 this.draw();
@@ -311,6 +319,7 @@ class LineChart extends Component {
             this.draw();
             this.removeObjLine(prevProps.objects, this.props.objects);
         }
+
 
     };
 
@@ -374,6 +383,18 @@ class LineChart extends Component {
         return name;
     }
 
+    removeLineFill = () =>{
+        for(const obj of this.props.objects) {
+            for (let counterKey in this.state.counters) {
+                let areaClass = "area-" + obj.objHash + "-" + this.replaceName(counterKey);
+                this.graph.svg.selectAll("path." + areaClass)
+                    .transition()
+                    .delay(100)
+                    .remove();
+            }
+        }
+
+    };
     removeObjectLine = (obj, counterKey) => {
         let pathClass = "line-" + obj.objHash + "-" + this.replaceName(counterKey);
         let path = this.graph.svg.selectAll("path." + pathClass);
@@ -426,11 +447,11 @@ class LineChart extends Component {
 
     drawObjectLine = (obj, option, counterKey, color) => {
         const that = this;
-
-        if (this.props.config.graph.fill === "Y") {
+        if (this.props.box.values['chartType'] === "LINE FILL") {
 
             let areaClass = "area-" + obj.objHash + "-" + this.replaceName(counterKey);
-            let area = this.graph.svg.selectAll("path." + areaClass);
+            let area = this.graph.svg.selectAll("path." + areaClass)
+
 
             if (area.size() < 1) {
                 area = this.graph.svg.insert("path", ":first-child").attr("class", areaClass).style("stroke", color);
@@ -448,7 +469,8 @@ class LineChart extends Component {
                     } else {
                         return that.graph.y(0);
                     }
-                });
+                })
+
 
             if (this.props.config.graph.break === "Y") {
                 valueArea.defined(function (d) {
@@ -459,9 +481,19 @@ class LineChart extends Component {
 
 
             if (!this.props.filterMap[obj.objHash]) {
-                area.data([that.state.counters[counterKey]]).attr("d", valueArea).style("fill", color).style("opacity", 0);
+                area.data([that.state.counters[counterKey]])
+                    .attr("d", valueArea)
+                    .style("fill", color)
+                    .style("opacity", 0)
+                    .transition()
+                    .delay(100);
             } else {
-                area.data([that.state.counters[counterKey]]).attr("d", valueArea).style("fill", color).style("opacity", this.props.config.graph.fillOpacity);
+                area.data([that.state.counters[counterKey]])
+                    .attr("d", valueArea)
+                    .style("fill", color)
+                    .style("opacity", this.props.config.graph.fillOpacity)
+                    .transition()
+                    .delay(100);
             }
         }
 

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -450,7 +450,7 @@ class LineChart extends Component {
 
         let instanceMetricCount = {};
         const color = {};
-
+        //- instance color making
         for (const attr  in this.props.objects) {
             const _obj = this.props.objects[attr];
             if (_obj.objFamily === thisOption.familyName) {
@@ -466,7 +466,7 @@ class LineChart extends Component {
                 }
             }
         }
-
+        //- instance data flat data making
         const stackData = _(this.state.counters[counterKey])
                             .map((d) => {
                                 const _r = Object.keys(d.data).map(key => {
@@ -479,9 +479,11 @@ class LineChart extends Component {
                                 });
                                 return _r;
                             }).flatMapDepth().value();
-
+        //- 인스턴스 별 데이터로 변환
         let ld = d3.nest().key(d => d.objHash).entries(stackData);
         const _sort = [];
+
+        //- 인스턴스 순서 정렬
         for (const attr  in this.props.objects) {
             const _obj = this.props.objects[attr];
             const _find = _.findIndex(ld, (o) =>  o.key === _obj.objHash);
@@ -490,6 +492,7 @@ class LineChart extends Component {
             }
 
         }
+        //- 인스턴스 그리기
         const area = d3.area().curve(d3[this.props.config.graph.curve])
             .x(d =>{
                 return this.graph.x(d[0]);
@@ -503,7 +506,9 @@ class LineChart extends Component {
             })
         }
 
+        //- 시간 별 Y축 데이터 어그리게이션
         let pre = {};
+        //- 차트 갱신
         let paintGroup = this.graph.svg.selectAll("path.line")
             .data(_sort)
             .attr("d",(d)=> {
@@ -515,9 +520,10 @@ class LineChart extends Component {
                             return [_node.time,next_v,pre_v];
                         });
                 return area(_d);
-            }); // 갱신
+            });
 
-        paintGroup.enter() // 신규 생성
+        //- 차트 생성
+        paintGroup.enter()
             .append('path')
             .attr("d",(d)=> {
                 const _d = _.map(d.values,(_node) =>{
@@ -541,6 +547,7 @@ class LineChart extends Component {
             .style("stroke-width", this.props.config.graph.width)
             .style("opacity", this.props.config.graph.opacity);
 
+         //- 차트 갱신 후 데이터 삭제
          paintGroup.exit().remove();
     };
 

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -808,9 +808,9 @@ class LineChart extends Component {
         if( this.chartType === "STACK AREA"){
             // - valueOut valid
             if( valueOutput ){
-                valueOutput = this.prevInstanceValue + valueOutput;
+                valueOutput = this.counterSum + valueOutput;
                 // change;
-                this.prevInstanceValue = valueOutput;
+                this.counterSum = valueOutput;
             }
 
         }
@@ -822,7 +822,7 @@ class LineChart extends Component {
                     circleKey: circleKey,
                     metricName: thisOption.title,
                     value: obj.objHash && that.state.counters[counterKey][dataIndex].data[obj.objHash] ? valueOutput : null,
-                    displayValue: obj.objHash && that.state.counters[counterKey][dataIndex].data[obj.objHash] ? numeral(valueOutput).format(this.props.config.numberFormat) + " " + unit : null,
+                    displayValue: obj.objHash && that.state.counters[counterKey][dataIndex].data[obj.objHash] ? numeral(that.state.counters[counterKey][dataIndex].data[obj.objHash].value).format(this.props.config.numberFormat) + " " + unit : null,
                     color: color
                 });
             }
@@ -867,8 +867,8 @@ class LineChart extends Component {
 
 
         this.graph.area = this.graph.svg.append("g")
-            .attr("class", "stack-area")
-            .attr("clip-path","url(#area-clip)");
+            .attr("class", "stack-area");
+            // .attr("clip-path","url(#area-clip)");
 
 
         this.graph.overlay = this.graph.svg.append("rect").attr("class", "tooltip-overlay").attr("width", this.graph.width).attr("height", this.graph.height);
@@ -978,7 +978,7 @@ class LineChart extends Component {
                 if (!thisOption) {
                     break;
                 }
-                that.prevInstanceValue = 0;
+                that.counterSum = 0;
                 for (let i = 0; i < that.props.objects.length; i++) {
                     const obj = that.props.objects[i];
                     if (thisOption.familyName === obj.objFamily) {
@@ -1021,6 +1021,8 @@ class LineChart extends Component {
                 }
             }
 
+            tooltip.chartType = that.chartType;
+            tooltip.counterSum = numeral(that.counterSum).format(that.props.config.numberFormat);
             that.graph.currentTooltipTime = tooltip.timeValue;
             that.props.showTooltip(xPos, yPos, that.graph.margin.left, that.graph.margin.top, tooltip);
         });

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -847,7 +847,7 @@ class LineChart extends Component {
             .attr("width", this.graph.width + this.graph.margin.left + this.graph.margin.right)
             .attr("height", this.graph.height + this.graph.margin.top + this.graph.margin.bottom);
 
-        this.graph.clipArea = d3.select(this.refs.lineChart).select("svg").append("defs")
+        d3.select(this.refs.lineChart).select("svg").append("defs")
             .append("svg:clipPath")
             .attr("id", `area-clip${this.props.box.key}`)
             .append("svg:rect")

--- a/src/components/Paper/LineChart/LineChart.js
+++ b/src/components/Paper/LineChart/LineChart.js
@@ -16,7 +16,7 @@ class LineChart extends Component {
     lastCountersHistoryTime = null;
     historyInit = {};
     chartType = "LINE";
-    boforeTimeFocusId = null;
+    timeFocusId = null;
     graph = {
         margin: {
             top: 15, right: 15, bottom: 25, left: 40
@@ -191,18 +191,21 @@ class LineChart extends Component {
 
         }
         //- 이전 툴팁이 고정 되었으면 자동 해지 할수 있도록 이벤트 체크
-        if( this.boforeTimeFocusId && !this.props.timeFocus.keep
-            && this.boforeTimeFocusId === this.props.box.key){
+        if( this.timeFocusId
+            && !this.props.timeFocus.keep
+            &&  this.timeFocusId === this.props.box.key){
             this.manualTooltipHide();
-            this.boforeTimeFocusId = null;
+            this.timeFocusId = null;
         }
 
         if( this.props.timeFocus.keep && this.props.box.key === nextProps.timeFocus.id){
-            this.boforeTimeFocusId = nextProps.timeFocus.id;
+            this.timeFocusId = nextProps.timeFocus.id;
         }
         //-
         this.chartType = nextProps.box.values['chartType'];
-        this.showTimeFocus(nextProps.timeFocus.active);
+        if(!this.props.timeFocus.keep) {
+            this.drawTimeFocus();
+        }
     }
 
     loadHistoryCounter(countersHistory, counterKey, longTerm) {
@@ -367,30 +370,7 @@ class LineChart extends Component {
         }
     };
 
-    showTimeFocus = (isShow=false) => {
-        if( isShow && !this.state.noData && this.props.timeFocus.id && this.props.timeFocus.id !== this.props.box.key) {
-            let hoverLine = this.graph.focus.selectAll("line.focus-line");
-            hoverLine.attr("x1", (d) =>this.graph.x(d))
-                     .attr("x2", (d) =>this.graph.x(d));
 
-            hoverLine.data([this.props.timeFocus.time])
-                .enter()
-                .append("line")
-                .attr("class", "focus-line focus-hover-line")
-                .attr("y1", 0)
-                .attr("y2", this.graph.height)
-                .attr("x1", (d) =>{
-                    return this.graph.x(d);
-                })
-                .attr("x2", (d) =>this.graph.x(d))
-                .exit()
-                .remove();
-        }else{
-            this.graph.focus.select("line.focus-line").remove();
-        }
-
-
-    };
 
     moveTooltip = () => {
         if (this.graph.currentTooltipTime) {
@@ -815,9 +795,40 @@ class LineChart extends Component {
             }
 
             this.moveTooltip();
+            if(this.props.timeFocus.keep) {
+                this.drawTimeFocus();
+            }
         }, 200);
 
     };
+
+
+    drawTimeFocus=()=>{
+
+        if( !this.state.noData
+            && this.props.timeFocus.active
+            && this.props.timeFocus.id !== this.props.box.key) {
+            let hoverLine = this.graph.focus.selectAll("line.focus-line");
+            hoverLine.attr("x1", (d) =>this.graph.x(d))
+                .attr("x2", (d) =>this.graph.x(d));
+
+            hoverLine.data([this.props.timeFocus.time])
+                .enter()
+                .append("line")
+                .attr("class", "focus-line focus-hover-line")
+                .attr("y1", 0)
+                .attr("y2", this.graph.height)
+                .attr("x1", (d) =>{
+                    return this.graph.x(d);
+                })
+                .attr("x2", (d) =>this.graph.x(d))
+                .exit()
+                .remove();
+        }else{
+            this.graph.focus.select("line.focus-line").remove();
+        }
+    };
+
 
 
     graphResize = () => {
@@ -827,7 +838,6 @@ class LineChart extends Component {
             resized = true;
             this.graphInit();
             this.manualTooltipHide();
-            this.props.setTimeFocus(false,null,this.props.box.key);
         }
 
         return resized;

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -3,7 +3,21 @@ import "./Paper.css";
 import "./Resizable.css";
 import {connect} from "react-redux";
 import {withRouter} from "react-router-dom";
-import {addRequest, pushMessage, setBoxes, setBoxesLayouts, setLayoutChangeTime, setControlVisibility, setLayouts, setRangeDateHoursMinutesValue, setRealTime, setTemplate, setBreakpoint, setTemplateName} from "../../actions";
+import {
+    addRequest,
+    pushMessage,
+    setBoxes,
+    setBoxesLayouts,
+    setLayoutChangeTime,
+    setControlVisibility,
+    setLayouts,
+    setRangeDateHoursMinutesValue,
+    setRealTime,
+    setTemplate,
+    setBreakpoint,
+    setTemplateName,
+    setTimeFocus
+} from "../../actions";
 import {Responsive, WidthProvider} from "react-grid-layout";
 import {Box, BoxConfig, XLogFilter} from "../../components";
 import jQuery from "jquery";
@@ -345,6 +359,8 @@ class Paper extends Component {
                 clearInterval(this.dataRefreshTimer);
                 this.dataRefreshTimer = null;
             }
+
+            this.props.setTimeFocus(false,null,this.props.timeFocus.id);
         }
 
         if (JSON.stringify(this.props.objects) !== JSON.stringify(nextProps.objects) || JSON.stringify(this.props.range) !== JSON.stringify(nextProps.range)) {
@@ -1503,7 +1519,8 @@ let mapStateToProps = (state) => {
         boxes: state.paper.boxes,
         layouts: state.paper.layouts,
         layoutChangeTime: state.paper.layoutChangeTime,
-        searchCondition: state.searchCondition
+        searchCondition: state.searchCondition,
+        timeFocus : state.timeFocus
     };
 };
 
@@ -1520,7 +1537,8 @@ let mapDispatchToProps = (dispatch) => {
         setBoxesLayouts: (boxes, layouts) => dispatch(setBoxesLayouts(boxes, layouts)),
         setLayoutChangeTime: () => dispatch(setLayoutChangeTime()),
         setBreakpoint: (breakpoint) => dispatch(setBreakpoint(breakpoint)),
-        setTemplateName: (preset, layout) => dispatch(setTemplateName(preset, layout))
+        setTemplateName: (preset, layout) => dispatch(setTemplateName(preset, layout)),
+        setTimeFocus: (active, time, boxKey,keep) => dispatch(setTimeFocus(active, time, boxKey,keep))
     };
 };
 

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -207,6 +207,18 @@ class Paper extends Component {
             rangeControl: false
         };
 
+        // 초기화 : 만약 라인 차트 타입 설정이 없는 경우
+
+        if( boxes ){
+            for (const key in boxes) {
+                if( !boxes[key].advancedOption && Array.isArray(boxes[key].option) ){
+                    boxes[key].advancedOption = Options.options().lineChart.config;
+                    for(const attr in boxes[key].advancedOption ){
+                        boxes[key].values[attr] =  boxes[key].advancedOption[attr].value;
+                    }
+                }
+            }
+        }
         this.props.setBoxesLayouts(boxes, layouts);
     }
 
@@ -268,12 +280,15 @@ class Paper extends Component {
 
         if (JSON.stringify(nextProps.template) !== JSON.stringify(this.props.template)) {
             if (JSON.stringify(nextProps.template.boxes) !== JSON.stringify(this.state.boxes) || JSON.stringify(nextProps.template.layouts) !== JSON.stringify(this.state.layouts)) {
-                // 초기화 : 템플릿 설정 및 박스 업데이트
+                // 초기화 : 만약 라인 차트 타입 설정이 없는 경우
                 const boxes = nextProps.template.boxes;
                 if( boxes ){
                     for (const key in boxes) {
                         if( !boxes[key].advancedOption && Array.isArray(boxes[key].option) ){
                             boxes[key].advancedOption = Options.options().lineChart.config;
+                            for(const attr in boxes[key].advancedOption ){
+                                boxes[key].values[attr] =  boxes[key].advancedOption[attr].value;
+                            }
                         }
                     }
                 }
@@ -1236,7 +1251,11 @@ class Paper extends Component {
                 for (let attr in option.config) {
                     box.values[attr] = option.config[attr].value;
                 }
-
+                if(option.advancedOption) {
+                    for (let attr in option.advancedOption) {
+                        box.values[attr] = option.advancedOption[attr].value;
+                    }
+                }
                 if (Array.isArray(box.option)) {
                     box.config = false;
                     let title = "";

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -1179,8 +1179,8 @@ class Paper extends Component {
 
     setOption = (key, option) => {
 
+        // paper init counter position : 2
         let boxes = this.props.boxes.slice(0);
-
         boxes.forEach((box) => {
             if (box.key === key) {
 

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -13,6 +13,7 @@ import Profiler from "./XLog/Profiler/Profiler";
 import ActiveService from "./ActiveService/ActiveService";
 import ServerDate from "../../common/ServerDate";
 import moment from "moment";
+import * as Options from "./PaperControl/Options"
 import OldVersion from "../OldVersion/OldVersion";
 
 const ResponsiveReactGridLayout = WidthProvider(Responsive);
@@ -55,11 +56,9 @@ class Paper extends Component {
                 }
             }
         }
-
         if (!(layouts)) {
             layouts = {};
         }
-
         if (!boxes) {
             boxes = [];
         }
@@ -211,8 +210,7 @@ class Paper extends Component {
         this.props.setBoxesLayouts(boxes, layouts);
     }
 
-    componentDidUpdate = (prevProps, prevState) => {
-
+    componentDidUpdate = (prevProps, nextState) => {
         let counterKeyMap = {};
         for (let i = 0; i < this.props.boxes.length; i++) {
             let option = this.props.boxes[i].option;
@@ -270,7 +268,16 @@ class Paper extends Component {
 
         if (JSON.stringify(nextProps.template) !== JSON.stringify(this.props.template)) {
             if (JSON.stringify(nextProps.template.boxes) !== JSON.stringify(this.state.boxes) || JSON.stringify(nextProps.template.layouts) !== JSON.stringify(this.state.layouts)) {
-                this.props.setBoxesLayouts(nextProps.template.boxes, nextProps.template.layouts);
+                // 초기화 : 템플릿 설정 및 박스 업데이트
+                const boxes = nextProps.template.boxes;
+                if( boxes ){
+                    for (const key in boxes) {
+                        if( !boxes[key].advancedOption && Array.isArray(boxes[key].option) ){
+                            boxes[key].advancedOption = Options.options().lineChart.config;
+                        }
+                    }
+                }
+                this.props.setBoxesLayouts(boxes, nextProps.template.layouts);
             }
         }
 

--- a/src/components/Paper/Paper.js
+++ b/src/components/Paper/Paper.js
@@ -1220,6 +1220,9 @@ class Paper extends Component {
                             familyName: option.familyName
                         });
                     }
+                    if(!box.advancedOption && option.advancedOption ){
+                        box.advancedOption = option.advancedOption;
+                    }
                 }
 
                 box.values = {};

--- a/src/components/Paper/PaperControl/Options.js
+++ b/src/components/Paper/PaperControl/Options.js
@@ -130,10 +130,12 @@ export function options() {
             type: "counter",
             title: "LINE CHART",
             config: {
-                name : "Chart Type",
-                type : "selector",
-                data : [ "LINE", "LINE FILL","STACK AREA"],
-                value : "LINE"
+                chartType : {
+                    name: "Chart Type",
+                    type: "selector",
+                    data: ["LINE", "LINE FILL", "STACK AREA"],
+                    value: "LINE"
+                }
             }
         }
 

--- a/src/components/Paper/PaperControl/Options.js
+++ b/src/components/Paper/PaperControl/Options.js
@@ -123,7 +123,21 @@ export function options() {
                     value: false
                 }
             }
-        }/*,
+        },
+        lineChart: {
+            icon: "fa-line-chart",
+            mode: "nonexclusive",
+            type: "counter",
+            title: "LINE CHART",
+            config: {
+                name : "Chart Type",
+                type : "selector",
+                data : [ "LINE", "LINE FILL","STACK AREA"],
+                value : "LINE"
+            }
+        }
+
+        /*,
         WAS: [
             {
                 text: "TPS",

--- a/src/components/Paper/PaperControl/PaperControl.js
+++ b/src/components/Paper/PaperControl/PaperControl.js
@@ -114,6 +114,7 @@ class PaperControl extends Component {
                                                 return a.displayName.localeCompare(b.displayName);
                                             }).map((counter, j) => {
                                                 counter.familyName = family.name;
+                                                counter.advancedOption = this.options["lineChart"].config;
                                                 return <li key={j}>
                                                     <Draggable type="metric" className="draggable paper-control-item" data={JSON.stringify(counter)}>
                                                         <div className="draggable-icon">draggable</div>
@@ -131,6 +132,7 @@ class PaperControl extends Component {
                                                 return a.displayName.localeCompare(b.displayName);
                                             }).map((counter, j) => {
                                                 counter.familyName = family.name;
+                                                counter.advancedOption = this.options["lineChart"].config;
                                                 return <li key={j}>
                                                     <div className="paper-control-item" onClick={this.props.addPaperAndAddMetric.bind(this, JSON.stringify(counter))}>
                                                         <span className="text-icon">{counter.displayName}</span>

--- a/src/components/Paper/PaperControl/PaperControl.js
+++ b/src/components/Paper/PaperControl/PaperControl.js
@@ -81,7 +81,7 @@ class PaperControl extends Component {
                                     <span className="toggle-filter-icon"><i className="fa fa-angle-down" aria-hidden="true"></i></span>
                                 </div>
                                 <ul>
-                                    {Object.keys(this.options).map((name, i) => {
+                                    {Object.keys(this.options).filter(name => name !== "lineChart").map((name, i) => {
                                         return <li key={i}>
                                             <div key={i} className="paper-control" data-tip={this.options[name].title} >
                                                 {(!this.touch) &&

--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -50,13 +50,16 @@ class XLog extends Component {
 
     resize = () => {
         this.graphResize();
+
     };
 
     componentWillReceiveProps(nextProps) {
         if (this.props.layoutChangeTime !== nextProps.layoutChangeTime) {
             this.graphResize();
         }
-        this.showTimeFocus(nextProps.timeFocus.active);
+        if(!this.props.timeFocus.keep) {
+            this.drawTimeFocus();
+        }
     }
 
     shouldComponentUpdate(nextProps, nextState) {
@@ -175,14 +178,13 @@ class XLog extends Component {
                     this.graphInit();
                 }
             }
-            this.props.setTimeFocus(false,null,this.props.box.key);
         }, 300);
     };
 
 
 
-    showTimeFocus = (isShow=false) => {
-        if( isShow && !this.state.noData && this.props.timeFocus.id && this.props.timeFocus.id !== this.props.box.key) {
+    drawTimeFocus = () => {
+        if( !this.state.noData && this.props.timeFocus.id && this.props.timeFocus.id !== this.props.box.key) {
             let hoverLine = this.graph.focus.selectAll("line.focus-line");
             hoverLine.attr("x1", (d) =>this.graph.x(d))
                 .attr("x2", (d) =>this.graph.x(d));
@@ -207,9 +209,12 @@ class XLog extends Component {
     };
 
     draw = async (xlogs, filter) => {
+        if(this.props.timeFocus.keep) {
+            this.drawTimeFocus();
+        }
         if (this.refs.xlogViewer && xlogs) {
             let context = d3.select(this.refs.xlogViewer).select("canvas").node().getContext("2d");
-            
+
             //let datas = common.getFilteredData(xlogs, filter);
             let datas = await common.getFilteredData0(xlogs, filter, this.props);
             datas.forEach((d, i) => {
@@ -238,6 +243,7 @@ class XLog extends Component {
                     }
                 }
             });
+
         }
     };
 

--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -198,6 +198,7 @@ class XLog extends Component {
                 .attr("x2", (d) =>this.graph.x(d))
                 .exit()
                 .remove();
+
         }else{
             this.graph.focus.select("line.focus-line").remove();
         }
@@ -391,31 +392,44 @@ class XLog extends Component {
 
         d3.select(this.refs.xlogViewer).select(".canvas-div")
             .on('mousemove',function() {
-                let xPos = d3.mouse(this)[0];
-                const x0 = that.graph.x.invert(xPos-that.graph.margin.left);
-                let hoverLine = that.graph.focus.selectAll("line.x-hover-line");
+                if(!that.props.timeFocus.keep) {
+                    let xPos = d3.mouse(this)[0];
+                    const x0 = that.graph.x.invert(xPos - that.graph.margin.left);
+                    let hoverLine = that.graph.focus.selectAll("line.x-hover-line");
 
-                hoverLine.attr("x1", (d) =>that.graph.x(d))
-                    .attr("x2", (d) =>that.graph.x(d));
+                    hoverLine.attr("x1", (d) => that.graph.x(d))
+                        .attr("x2", (d) => that.graph.x(d));
 
-                hoverLine.data([x0])
-                    .enter()
-                    .append("line")
-                    .attr("class", "x-hover-line hover-line")
-                    .attr("y1", 0)
-                    .attr("y2", that.graph.height)
-                    .attr("x1", (d) =>{
-                        return that.graph.x(d);
-                    })
-                    .attr("x2", (d) =>that.graph.x(d))
-                    .exit()
-                    .remove();
+                    hoverLine.data([x0])
+                        .enter()
+                        .append("line")
+                        .attr("class", "x-hover-line hover-line")
+                        .attr("y1", 0)
+                        .attr("y2", that.graph.height)
+                        .attr("x1", (d) => {
+                            return that.graph.x(d);
+                        })
+                        .attr("x2", (d) => that.graph.x(d))
+                        .exit()
+                        .remove();
 
-                that.props.setTimeFocus(true, x0.getTime(), that.props.box.key);
+                    that.props.setTimeFocus(true, x0.getTime(), that.props.box.key);
+                }
             })
             .on('mouseout',() =>{
-                that.graph.focus.select("line.x-hover-line").remove();
-                that.props.setTimeFocus(false, null, that.props.box.key);
+                if(!this.props.timeFocus.keep) {
+                    this.graph.focus.select("line.x-hover-line").remove();
+                    this.props.setTimeFocus(false, null, that.props.box.key);
+                }
+            })
+            .on('dblclick',()=>{
+                this.props.setTimeFocus(
+                    this.props.timeFocus.active,
+                    this.props.timeFocus.time,
+                    this.props.timeFocus.id,
+                    !this.props.timeFocus.keep
+                );
+
             });
 
         // 드래그 셀렉트
@@ -609,7 +623,7 @@ let mapStateToProps = (state) => {
 let mapDispatchToProps = (dispatch) => {
     return {
         setSelection: (selection) => dispatch(setSelection(selection)),
-        setTimeFocus: (active, time, boxKey) => dispatch(setTimeFocus(active, time, boxKey))
+        setTimeFocus: (active, time, boxKey,keep) => dispatch(setTimeFocus(active, time, boxKey,keep))
     };
 };
 

--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -175,6 +175,7 @@ class XLog extends Component {
                     this.graphInit();
                 }
             }
+            this.props.setTimeFocus(false,null,this.props.box.key);
         }, 300);
     };
 

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -645,7 +645,8 @@ const templateName = (state = templateNameState, action) => {
 const timeFocusState = {
     active : false,
     time : null,
-    id : null
+    id : null,
+    keep : false,
 };
 
 const timeFocus =(state=timeFocusState, action ) =>{
@@ -655,6 +656,7 @@ const timeFocus =(state=timeFocusState, action ) =>{
                 active : action.active,
                 time: action.time,
                 id: action.id,
+                keep : action.keep
             };
         default:
             return state;

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -1,4 +1,48 @@
-import {SET_ACTIVE_SERVICE,SET_MENU, SET_BOXES_LAYOUTS, SET_LAYOUTS, SET_BOXES, SET_LAYOUT_CHANGETIME, SET_SUPPORTED, ADD_REQUEST, SET_CONFIG, SET_USER_ID, SET_USER_DATA, SET_TARGET, PUSH_MESSAGE, SET_CONTROL_VISIBILITY, CLEAR_ALL_MESSAGE, SET_BG_COLOR, SET_SELECTION, SET_TEMPLATE, SET_REAL_TIME, SET_RANGE_DATE, SET_RANGE_HOURS, SET_RANGE_MINUTES, SET_RANGE_VALUE, SET_REAL_TIME_VALUE, SET_FROM_PAST, SET_RANGE_DATE_HOURS_MINUTES, SET_REAL_TIME_RANGE_STEP_VALUE, SET_RANGE_DATE_HOURS_MINUTES_VALUE, SET_RANGE_ALL, SET_COUNTER_INFO, SET_CONTROLLER_STATE, SET_CONTROLLER_PIN, SET_FILTER_MAP, ADD_FILTERED_OBJECT, REMOVE_FILTERED_OBJECT, SET_SEARCH_CONDITION, SET_TOPOLOGY_OPTION, SET_ALERT, SET_BREAKPOINT, SET_TEMPLATE_NAME, SET_PRESET_NAME, SET_LAYOUT_NAME} from '../actions';
+import {
+    SET_ACTIVE_SERVICE,
+    SET_MENU,
+    SET_BOXES_LAYOUTS,
+    SET_LAYOUTS,
+    SET_BOXES,
+    SET_LAYOUT_CHANGETIME,
+    SET_SUPPORTED,
+    ADD_REQUEST,
+    SET_CONFIG,
+    SET_USER_ID,
+    SET_USER_DATA,
+    SET_TARGET,
+    PUSH_MESSAGE,
+    SET_CONTROL_VISIBILITY,
+    CLEAR_ALL_MESSAGE,
+    SET_BG_COLOR,
+    SET_SELECTION,
+    SET_TEMPLATE,
+    SET_REAL_TIME,
+    SET_RANGE_DATE,
+    SET_RANGE_HOURS,
+    SET_RANGE_MINUTES,
+    SET_RANGE_VALUE,
+    SET_REAL_TIME_VALUE,
+    SET_FROM_PAST,
+    SET_RANGE_DATE_HOURS_MINUTES,
+    SET_REAL_TIME_RANGE_STEP_VALUE,
+    SET_RANGE_DATE_HOURS_MINUTES_VALUE,
+    SET_RANGE_ALL,
+    SET_COUNTER_INFO,
+    SET_CONTROLLER_STATE,
+    SET_CONTROLLER_PIN,
+    SET_FILTER_MAP,
+    ADD_FILTERED_OBJECT,
+    REMOVE_FILTERED_OBJECT,
+    SET_SEARCH_CONDITION,
+    SET_TOPOLOGY_OPTION,
+    SET_ALERT,
+    SET_BREAKPOINT,
+    SET_TEMPLATE_NAME,
+    SET_PRESET_NAME,
+    SET_LAYOUT_NAME,
+    SET_TIME_FOCUS,
+} from '../actions';
 import {combineReducers} from 'redux';
 import moment from 'moment';
 const configState = {
@@ -436,6 +480,7 @@ const paper = (state = paperState, action) => {
     }
 };
 
+
 const searchConditionState = {
     from: null,
     to : null,
@@ -597,6 +642,24 @@ const templateName = (state = templateNameState, action) => {
     }
 };
 
+const timeFocusState = {
+    active : false,
+    time : null,
+    id : null
+};
+
+const timeFocus =(state=timeFocusState, action ) =>{
+    switch (action.type) {
+        case SET_TIME_FOCUS:
+            return {
+                active : action.active,
+                time: action.time,
+                id: action.id,
+            };
+        default:
+            return state;
+    }
+};
 const scouterApp = combineReducers({
     supported,
     target,
@@ -613,7 +676,8 @@ const scouterApp = combineReducers({
     paper,
     topologyOption,
     alert,
-    templateName
+    templateName,
+    timeFocus
 });
 
 export default scouterApp;


### PR DESCRIPTION
# 1. Stack Type 구현 내용 
 -  차트 타입 설정 옵션 기능 추가 
    -  Line,Line Fill,Stack Area
    - 차트 타입 설정 변경 시 기존 차트 내용을 지우고 현재 설정된 차트 타입으로 변경할수 있도록 함 
          - Line => Line Fill 
          - Line Fill => Line 
          - Line  => Stack Area 
          - Line Fill => Stack Area 
          - Stack Area => Line 
          - Stack Area => Line Fill
    -  Stack Area 차트인 경우 차트당 하나의 메트릭만 허용 
        - 메트릭 데이터는 하나만 허용 해야 하는 경고 메시지 추가 
- Stack  Area 차트에서 툴팁을 표현할때는 SUM(합계) 추가 툴팁 추가 
- 기본 레이아웃 설정 로딩시 , 차트 타입 설정 기능 추가 
    - 기본 레이아웃 설정 로딩 후에 Stack Area로 변경시에는 최소 한번은 Layout 설정을 저장 해야 함 
-  Stack Area 차트에 메트릭 추가를 할경우 자동으로 Line 차트로 변경 (이건 default로 되어 있어 변경사항 없음)
# 2. Stack Area 차트 결과 
- TPS 라인 차트 => Stack Area 차트 변경시 결과 
![image](https://user-images.githubusercontent.com/18545293/58765009-454aad80-85a9-11e9-8886-4b0658f203b1.png)


