### PR TITLE
IOS 에서 Paper 화면이 파란색 화면만 나오는 현상 수정 

### DIFF
--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -28,10 +28,11 @@ class Menu extends Component {
             menu: this.props.location.pathname
         });
         this.props.setMenu(this.props.location.pathname);
-
         if (this.props.config.alert.notification === "Y") {
-            if (Notification && (Notification.permission !== "granted" || Notification.permission === "denied")) {
-                Notification.requestPermission();
+            if( typeof Notification === 'function' && Notification.hasOwnProperty('permission')) {
+                if( Notification.permission !== "granted" || Notification.permission === "denied") {
+                    Notification.requestPermission();
+                }
             }
         }
     }


### PR DESCRIPTION
## IOS에서 Paper 접속 시 파란 화면만 나오는 현상 #154
 -  IOS 브라우저 Notification 클래스가 존재 하지 않아 렌더링이 되지 않는 현상 수정 
 - 해당 원인 모바일 브라우저 사바리에서 발생 하는 현상으로 Menu를 초기화 하는 과정에서 발생 

## work ground 상세 정보 
 - 테스팅 환경 정보 
   - 모바일 사바리 12.1.1
   - IOS 12.3.1 
   - IPhone

## 오류 상세 정보 
![image](https://user-images.githubusercontent.com/18545293/59397448-9fc4e480-8dc7-11e9-9ce7-234e196f27dc.png)



