### PR TITLE
[issue-201] Gray 테마에서 프로파일링 타임 Ratio 항목이 보이지 않는 현상 수정 

### DIFF
--- a/src/Theme.css
+++ b/src/Theme.css
@@ -285,6 +285,9 @@ html.theme-gray, .theme-gray body {
 .theme-gray .frame-profile div.xlog-data span.label {
     background-color: #111;
 }
+.theme-gray .frame-profile div.time-ratio{
+    background-color: #111;
+}
 
 .theme-gray .frame-xlog-steps .step {
     background-color: #111;


### PR DESCRIPTION
# 수정 이전 
![image](https://user-images.githubusercontent.com/18545293/59703246-70cdc900-9234-11e9-90b3-64005e2de8b8.png)

# 수정 결과 
![image](https://user-images.githubusercontent.com/18545293/59703116-2b110080-9234-11e9-9e63-780c843fd407.png)

- Gray Theme 수정 
