### PR TITLE
페이퍼 탭에서 API 서버 3개 이상시 선택 불가 이슈 수정  #200

### DIFF
--- a/src/components/Controller/Controller.js
+++ b/src/components/Controller/Controller.js
@@ -1067,7 +1067,7 @@ class Controller extends Component {
                             </div>
                         </div>
                     </div>
-                    <div className="control-item paper-only" style={{zIndex: 1}}>
+                    <div className="control-item paper-only">
                         <div className="row desc">
                             <div className="step"><span>3</span></div>
                             <div className="row-message">SEARCH</div>


### PR DESCRIPTION
# 수정 전 
![image](https://user-images.githubusercontent.com/18545293/59729269-97155800-9278-11e9-9a44-150df1ff113b.png)

# 수정 후 
![image](https://user-images.githubusercontent.com/18545293/59729276-a1cfed00-9278-11e9-9576-ba8e88646f6c.png)

- 발생 원인 페이퍼 컨트롤 Search 항목 Div 박스 z-index가 먹혀 select api server 목록과 겹치는 현상이었음 
  해당 문제 수정 함

