### PR TITLE
Gray Theme 에서 토폴로지 차트 노드 툴팁 내용이 보이지 않는 현상 수정 / issue-226

### DIFF
--- a/src/Theme.css
+++ b/src/Theme.css
@@ -78,6 +78,10 @@ html.theme-gray {
     stroke: #deffba;
 }
 
+/* THEME, topology-chart.css */
+.theme-gray .topology-wrapper .tooltip-group{
+    color: #111;
+}
 
 /* THEME, Login.css */
 .theme-gray .login-wrapper .login-box {


### PR DESCRIPTION
# 수정 전 
![image](https://user-images.githubusercontent.com/18545293/60004491-b0b70500-96a7-11e9-8ffd-11f334a9bde3.png)

# 수정 후 
![image](https://user-images.githubusercontent.com/18545293/60004453-9bda7180-96a7-11e9-8a4f-fe5d08644a67.png)

 - Gray 테마에 토폴로지 차트 툴팁 내용이 보이도록 CSS 수정 함 
