### PR TITLE
#192 xlog 드래그시에 목록에 더블로 표현됨.

### DIFF
--- a/src/components/Paper/XLog/Profiler/Profiler.js
+++ b/src/components/Paper/XLog/Profiler/Profiler.js
@@ -302,8 +302,7 @@ class Profiler extends Component {
         }
 
         // remove duplication txid
-        var arrTxid = (filtered.map(x => x.txid).toString()).split(",");
-        var strTxid = arrTxid.reduce(function(a,b){ if(a.indexOf(b) < 0) a.push(b); return a;},[]);
+        let strTxid = filtered.map(x => x.txid).reduce(function(a,b){ if(a.indexOf(b) < 0) a.push(b); return a;},[]);
 
         let date = moment(new Date(x1)).format("YYYYMMDD");
 

--- a/src/components/Paper/XLog/Profiler/Profiler.js
+++ b/src/components/Paper/XLog/Profiler/Profiler.js
@@ -301,6 +301,10 @@ class Profiler extends Component {
             return;
         }
 
+        // remove duplication txid
+        var arrTxid = (filtered.map(x => x.txid).toString()).split(",");
+        var strTxid = arrTxid.reduce(function(a,b){ if(a.indexOf(b) < 0) a.push(b); return a;},[]);
+
         let date = moment(new Date(x1)).format("YYYYMMDD");
 
         this.props.setControlVisibility("Loading", true);
@@ -308,7 +312,7 @@ class Profiler extends Component {
         jQuery.ajax({
             method: "GET",
             async: true,
-            url: getHttpProtocol(this.props.config) + '/scouter/v1/xlog-data/' + date + '/multi/' + filtered.map(x => x.txid).toString(),
+            url: getHttpProtocol(this.props.config) + '/scouter/v1/xlog-data/' + date + '/multi/' + strTxid,
             xhrFields: getWithCredentials(that.props.config),
             beforeSend: function (xhr) {
                 setAuthHeader(xhr, that.props.config, getCurrentUser(that.props.config, that.props.user));

--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -142,11 +142,9 @@ class XLog extends Component {
             this.redraw(this.props.filter);
         } else if (this.lastPastTimestamp === this.props.pastTimestamp && this.lastPageCnt !== this.props.pageCnt) {
             this.lastPageCnt = this.props.pageCnt;
-            this.clear();
             this.draw(this.props.data.newXLogs, this.props.filter);
         } else {
-            this.clear();
-            this.redraw(this.props.filter);
+            this.draw(this.props.data.newXLogs, this.props.filter);
         }
         
         if (this.props.filter && JSON.stringify(prevProps.filter) !== JSON.stringify(this.props.filter)) {

--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -144,7 +144,7 @@ class XLog extends Component {
             this.lastPageCnt = this.props.pageCnt;
             this.draw(this.props.data.newXLogs, this.props.filter);
         } else {
-            this.draw(this.props.data.newXLogs, this.props.filter);
+            this.redraw(this.props.filter);
         }
         
         if (this.props.filter && JSON.stringify(prevProps.filter) !== JSON.stringify(this.props.filter)) {

--- a/src/components/Paper/XLog/XLog.js
+++ b/src/components/Paper/XLog/XLog.js
@@ -142,8 +142,10 @@ class XLog extends Component {
             this.redraw(this.props.filter);
         } else if (this.lastPastTimestamp === this.props.pastTimestamp && this.lastPageCnt !== this.props.pageCnt) {
             this.lastPageCnt = this.props.pageCnt;
+            this.clear();
             this.draw(this.props.data.newXLogs, this.props.filter);
         } else {
+            this.clear();
             this.redraw(this.props.filter);
         }
         


### PR DESCRIPTION
#192 xlog 드래그시에 목록에 더블로 표현됨.

- 현상
  - 중복된 데이터가 프로파일 리스트에 나타남.
  - 비규칙적으로 나타남 (모니터가 절전모드로 갔다 오면 자주 발견됨 - 인터넷 불능시?)

- 원인
  - 프로파일 리스트를 호출할때 파라미터로 동일한 txid 값이 넘어가서 response 데이터가 중복되어 나타남

- 처리
  - 단기 : txid 중복 데이터 제거 로직을 추가하여 처리함.
  - 장기 : 특정 환경에서 XLog 이 중복되어 데이터가 찍히는것으로 추정되며, 장기적으로 추적 필요.
  
 